### PR TITLE
Added repo to metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Tauri Programme within The Commons Conservancy"]
 license = "Apache-2.0 OR MIT"
 rust-version = "1.70"
 links = "tauri-plugin-serialplugin"
+repository = "https://github.com/s00d/tauri-plugin-serialplugin"
 
 [package.metadata.docs.rs]
 rustc-args = [ "--cfg", "docsrs" ]


### PR DESCRIPTION
Wonderful plugin here!

I always like to once over the crate before I install it from crates.io, however when I stumbled upon this plugin I became concerned that the repo wasn't there. This turned out to not be an issue, but it would help if you added it, to make it easier for people to access the repo!

