### PR TITLE
fix(serial) make extremely fast serial input work 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,ts,svelte,html,json,mjs,cjs}]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/examples/serialport-test/src/App.svelte
+++ b/examples/serialport-test/src/App.svelte
@@ -104,7 +104,7 @@
         </h3>
         {#if Object.keys(availablePorts).length > 0}
           <ul>
-            {#each Object.entries(availablePorts) as [portName, info]}
+            {#each Object.entries(availablePorts).sort( (a, b) => a[0].localeCompare(b[0]), ) as [portName, info]}
               <li>
                 <span>{portName} — {info.type}</span>
                 <button on:click={() => addPort(portName)}>+</button>
@@ -124,7 +124,7 @@
         </h3>
         {#if Object.keys(directPorts).length > 0}
           <ul>
-            {#each Object.entries(directPorts) as [portName, info]}
+            {#each Object.entries(directPorts).sort( (a, b) => a[0].localeCompare(b[0]), ) as [portName, info]}
               <li>
                 <span>{portName} — {info.type}</span>
                 <button on:click={() => addPort(portName)}>+</button>
@@ -176,7 +176,7 @@
 <style>
   /* Пример стилистики, вы можете дополнять/менять по вкусу */
   .title {
-    color: #fff;
+    color: #fff !important;
     padding-bottom: 30px;
   }
 

--- a/examples/serialport-test/src/App.svelte
+++ b/examples/serialport-test/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { SerialPort } from 'tauri-plugin-serialplugin';
-  import SerialPortComponent from './components/SerialPortComponent.svelte';
+  import { onMount } from "svelte";
+  import { SerialPort } from "tauri-plugin-serialplugin";
+  import SerialPortComponent from "./components/SerialPortComponent.svelte";
 
   // Списки найденных портов
   let availablePorts: { [key: string]: { type: string } } = {};
@@ -12,33 +12,33 @@
   let activePorts: string[] = [];
 
   // Поле для ручного ввода пути
-  let manualPath: string = '';
+  let manualPath: string = "";
 
   // Сканируем порты
   async function scanPorts() {
     try {
       availablePorts = await SerialPort.available_ports();
-      console.log('Available ports:', availablePorts);
+      console.log("Available ports:", availablePorts);
     } catch (err) {
-      console.error('Failed to scan ports:', err);
+      console.error("Failed to scan ports:", err);
     }
   }
 
   async function scanPortsDirect() {
     try {
       directPorts = await SerialPort.available_ports_direct();
-      console.log('Direct ports:', directPorts);
+      console.log("Direct ports:", directPorts);
     } catch (err) {
-      console.error('Failed to scan ports directly:', err);
+      console.error("Failed to scan ports directly:", err);
     }
   }
 
   async function showManagedPorts() {
     try {
       managedPorts = await SerialPort.managed_ports();
-      console.log('Managed ports:', managedPorts);
+      console.log("Managed ports:", managedPorts);
     } catch (err) {
-      console.error('Failed to get Managed ports:', err);
+      console.error("Failed to get Managed ports:", err);
     }
   }
 
@@ -60,12 +60,12 @@
     const path = manualPath.trim();
     if (path) {
       addPort(path);
-      manualPath = '';
+      manualPath = "";
     }
   }
 
   function handleDisconnect({ port }: { port: string }) {
-    console.log('handleDisconnect сработал, порт:', port);
+    console.log("handleDisconnect сработал, порт:", port);
     removePort(port);
   }
 
@@ -78,16 +78,16 @@
 </script>
 
 <main class="container">
-  <h1>Multi-Port Serial Demo</h1>
+  <h1 class="title">Multi-Port Serial Demo</h1>
 
   <!-- Ручной ввод пути -->
   <section class="manual-connect">
     <h2>Manual Port Input</h2>
     <div class="row">
       <input
-              type="text"
-              placeholder="Enter port path (e.g. /dev/ttyACM0)..."
-              bind:value={manualPath}
+        type="text"
+        placeholder="Enter port path (e.g. /dev/ttyACM0)..."
+        bind:value={manualPath}
       />
       <button on:click={addManualPort}>+</button>
     </div>
@@ -164,10 +164,7 @@
     {#if activePorts.length > 0}
       {#each activePorts as portName}
         <div class="port-wrapper">
-          <SerialPortComponent
-                  portName={portName}
-                  onDisconnect={handleDisconnect}
-          />
+          <SerialPortComponent {portName} onDisconnect={handleDisconnect} />
         </div>
       {/each}
     {:else}
@@ -178,6 +175,14 @@
 
 <style>
   /* Пример стилистики, вы можете дополнять/менять по вкусу */
+  .title {
+    color: #fff;
+    padding-bottom: 30px;
+  }
+
+  main {
+    color: #333;
+  }
 
   .container {
     max-width: 1200px;
@@ -186,7 +191,9 @@
     font-family: sans-serif;
   }
 
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     margin-bottom: 10px;
     color: #333;
   }

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -3,13 +3,13 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from '@tauri-apps/api/event';
 
 export interface PortInfo {
-  path: "Unknown"|string;
-  manufacturer: "Unknown"|string;
-  pid: "Unknown"|string;
-  product: "Unknown"|string;
-  serial_number: "Unknown"|string;
-  type: "PCI"|string;
-  vid: "Unknown"|string;
+  path: "Unknown" | string;
+  manufacturer: "Unknown" | string;
+  pid: "Unknown" | string;
+  product: "Unknown" | string;
+  serial_number: "Unknown" | string;
+  type: "PCI" | string;
+  vid: "Unknown" | string;
 }
 
 export interface InvokeResult {
@@ -83,8 +83,8 @@ export enum ClearBuffer {
   All = "All"
 }
 
-let tester_ports: {[key: string]: SerialPort} = {}
-let tester_listeners: {[key: string]: (...args: any[]) => void} = {}
+let tester_ports: { [key: string]: SerialPort } = {}
+let tester_listeners: { [key: string]: (...args: any[]) => void } = {}
 
 setInterval(() => {
   for (let path in tester_listeners) {
@@ -182,7 +182,7 @@ class SerialPort {
    * @returns {Promise<void>} A promise that resolves when the port is closed
    */
   static async forceClose(path: string): Promise<void> {
-    if(tester_ports[path]) {
+    if (tester_ports[path]) {
       delete tester_ports[path]
       return Promise.resolve();
     }
@@ -295,16 +295,16 @@ class SerialPort {
     let checkEvent = `plugin-serialplugin-disconnected-${sub_path}`;
     console.log('listen event: ' + checkEvent)
     let unListen: any = await listen<ReadDataResult>(
-        checkEvent,
-        () => {
-          try {
-            fn();
-            unListen();
-            unListen = undefined;
-          } catch (error) {
-            console.error(error);
-          }
-        },
+      checkEvent,
+      () => {
+        try {
+          fn();
+          unListen();
+          unListen = undefined;
+        } catch (error) {
+          console.error(error);
+        }
+      },
     );
   }
 
@@ -331,20 +331,20 @@ class SerialPort {
       }
 
       this.unListen = await listen<ReadDataResult>(
-          readEvent,
-          ({ payload }) => {
-            try {
-              if (isDecode) {
-                const decoder = new TextDecoder(this.encoding);
-                const data = decoder.decode(new Uint8Array(payload.data));
-                fn(data);
-              } else {
-                fn(new Uint8Array(payload.data));
-              }
-            } catch (error) {
-              console.error(error);
+        readEvent,
+        ({ payload }) => {
+          try {
+            if (isDecode) {
+              const decoder = new TextDecoder(this.encoding);
+              const data = decoder.decode(new Uint8Array(payload.data));
+              fn(data);
+            } else {
+              fn(new Uint8Array(payload.data));
             }
-          },
+          } catch (error) {
+            console.error(error);
+          }
+        },
       );
       return;
     } catch (error) {
@@ -447,7 +447,7 @@ class SerialPort {
     try {
       if (this.is_test) {
         const resp = '';
-        if(tester_listeners[this.options.path!]) {
+        if (tester_listeners[this.options.path!]) {
           tester_listeners[this.options.path!](resp);
         }
         return Promise.resolve('');
@@ -473,7 +473,7 @@ class SerialPort {
       if (this.is_test) {
         // Тестовые данные
         const resp = new Uint8Array();
-        if(tester_listeners[this.options.path!]) {
+        if (tester_listeners[this.options.path!]) {
           tester_listeners[this.options.path!](resp);
         }
         return Promise.resolve(new Uint8Array());
@@ -791,7 +791,7 @@ class SerialPort {
         });
       } else {
         return Promise.reject(
-            'value Argument type error! Expected type: string, Uint8Array, number[]',
+          'value Argument type error! Expected type: string, Uint8Array, number[]',
         );
       }
     } catch (error) {


### PR DESCRIPTION
Serial connections that rapidly send a lot of data tend to have random sections of data missing. I've narrowed this down to the timeout option.

Removing the timeout altogether causes Tauri apps to crash, so I use the timeout option as the time to send the combined buffer. This fixes the issue that occurs when too much data is sent too fast from the device.

Additionally, this PR includes some quality-of-life improvements for the playground, such as alphabetically sorting ports and fixing some styles.