### PR TITLE
fix(serial) prevent empty read emission

### DIFF
--- a/src/desktop_api.rs
+++ b/src/desktop_api.rs
@@ -476,10 +476,16 @@ impl<R: Runtime> SerialPort<R> {
                     if elapsed_time > Duration::from_millis(timeout.unwrap_or(200)) {
                         start_time = Instant::now();
 
+                        let size = combined_buffer.len();
+
+                        if size == 0 {
+                            continue;
+                        }
+
                         if let Err(e) = app_clone.emit(
                             &read_event,
                             ReadData {
-                                size: combined_buffer.len(),
+                                size,
                                 data: combined_buffer.as_mut_slice(),
                             },
                         ) {


### PR DESCRIPTION
Added a check to skip emitting the `ReadData` event when the `combined_buffer` is empty. This prevents unnecessary emissions and potential overhead when no data is available. The check ensures that `app_clone.emit` is only called if there is actual data to process.