### PR TITLE
fix(android): run port IO commands off the main thread

### DIFF
--- a/android/src/main/kotlin/app/tauri/serialplugin/SerialPlugin.kt
+++ b/android/src/main/kotlin/app/tauri/serialplugin/SerialPlugin.kt
@@ -16,6 +16,9 @@ import app.tauri.serialplugin.models.*
 import android.webkit.WebView
 import android.util.Log
 import app.tauri.plugin.JSArray
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 // --- Reused from previous answer (Converts a Map to a JSObject) ---
 fun Map<String, Any?>.toJSObject(): JSObject {
     val jsObject = JSObject()
@@ -97,6 +100,24 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     /** Unregistered after [activity] is destroyed so we do not leak the callback. */
     private var activityDestroyCallback: Application.ActivityLifecycleCallbacks? = null
 
+    /**
+     * Plugin commands are dispatched synchronously on the Android main looper, so a
+     * blocking `UsbSerialPort.read`/`write`/permission wait inside a command freezes the
+     * UI (polled reads block the main thread for up to the read timeout, per chunk).
+     * All port IO commands run here instead; a single thread preserves command ordering.
+     */
+    private val ioExecutor: ExecutorService = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "serialplugin-io")
+    }
+
+    private fun runOnIoThread(invoke: Invoke, block: () -> Unit) {
+        try {
+            ioExecutor.execute(block)
+        } catch (e: RejectedExecutionException) {
+            invoke.reject("Serial IO executor is shut down")
+        }
+    }
+
     override fun load(webView: WebView) {
         super.load(webView)
         serialPortManager = SerialPortManager(activity) { path, message ->
@@ -131,6 +152,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
                 } catch (e: Exception) {
                     Log.e("SerialPlugin", "cleanup on activity destroy failed: ${e.message}", e)
                 } finally {
+                    ioExecutor.shutdown()
                     unregisterActivityDestroyCleanup()
                 }
             }
@@ -187,7 +209,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun open(invoke: Invoke) {
+    fun open(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             Log.d("SerialPlugin", "Opening port: ${args.path}")
@@ -245,7 +267,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun write(invoke: Invoke) {
+    fun write(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(WriteArgs::class.java)
             Log.d("SerialPlugin", "Writing to port: ${args.path}, data: ${args.value}")
@@ -261,7 +283,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun close(invoke: Invoke) {
+    fun close(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             Log.d("SerialPlugin", "Closing port: ${args.path}")
@@ -275,7 +297,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun closeAll(invoke: Invoke) {
+    fun closeAll(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             Log.d("SerialPlugin", "Closing all ports")
             serialPortManager.closeAllPorts()
@@ -288,7 +310,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun forceClose(invoke: Invoke) {
+    fun forceClose(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             Log.d("SerialPlugin", "Force closing port: ${args.path}")
@@ -302,7 +324,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun writeBinary(invoke: Invoke) {
+    fun writeBinary(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(WriteBinaryArgs::class.java)
             Log.d("SerialPlugin", "Writing binary to port: ${args.path}")
@@ -319,7 +341,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun read(invoke: Invoke) {
+    fun read(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             Log.d("SerialPlugin", "Reading from port: ${args.path}")
@@ -335,7 +357,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun readBinary(invoke: Invoke) {
+    fun readBinary(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             Log.d("SerialPlugin", "Reading binary from port: ${args.path}")

--- a/android/src/main/kotlin/app/tauri/serialplugin/SerialPlugin.kt
+++ b/android/src/main/kotlin/app/tauri/serialplugin/SerialPlugin.kt
@@ -104,7 +104,9 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
      * Plugin commands are dispatched synchronously on the Android main looper, so a
      * blocking `UsbSerialPort.read`/`write`/permission wait inside a command freezes the
      * UI (polled reads block the main thread for up to the read timeout, per chunk).
-     * All port IO commands run here instead; a single thread preserves command ordering.
+     * Every command that touches [SerialPortManager] runs here instead: its internal
+     * state (`portMap`) is not thread-safe, so funneling all access through one thread
+     * both keeps the main thread free and preserves command ordering.
      */
     private val ioExecutor: ExecutorService = Executors.newSingleThreadExecutor { r ->
         Thread(r, "serialplugin-io")
@@ -148,9 +150,18 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
                 if (destroyed !== activity) return
                 try {
                     Log.d("SerialPlugin", "Activity destroyed — releasing USB serial resources")
+                    // Enqueue cleanup behind any pending IO so queued read/write tasks
+                    // do not run against already-released ports, then stop the executor.
+                    ioExecutor.execute {
+                        try {
+                            serialPortManager.cleanup()
+                        } catch (e: Exception) {
+                            Log.e("SerialPlugin", "cleanup on activity destroy failed: ${e.message}", e)
+                        }
+                    }
+                } catch (e: RejectedExecutionException) {
+                    // Executor already stopped; release directly.
                     serialPortManager.cleanup()
-                } catch (e: Exception) {
-                    Log.e("SerialPlugin", "cleanup on activity destroy failed: ${e.message}", e)
                 } finally {
                     ioExecutor.shutdown()
                     unregisterActivityDestroyCleanup()
@@ -179,7 +190,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun availablePorts(invoke: Invoke) {
+    fun availablePorts(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             Log.d("SerialPlugin", "Fetching available ports")
             val ports = serialPortManager.getAvailablePorts()
@@ -195,7 +206,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun managedPorts(invoke: Invoke) {
+    fun managedPorts(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val managedPorts = serialPortManager.getManagedPorts()
             Log.d("SerialPlugin", "Managed ports: ${managedPorts.size} ports")
@@ -374,7 +385,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun startListening(invoke: Invoke) {
+    fun startListening(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(StartListenArgs::class.java)
             val path = args.path
@@ -398,7 +409,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun stopListening(invoke: Invoke) {
+    fun stopListening(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             Log.d("SerialPlugin", "Stopping listening on port: ${args.path}")
@@ -412,7 +423,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setBaudRate(invoke: Invoke) {
+    fun setBaudRate(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val success = serialPortManager.setBaudRate(args.path, args.baudRate)
@@ -427,7 +438,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setDataBits(invoke: Invoke) {
+    fun setDataBits(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val dataBits = when (args.dataBits) {
@@ -448,7 +459,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setFlowControl(invoke: Invoke) {
+    fun setFlowControl(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val flowControl = when (args.flowControl) {
@@ -469,7 +480,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setParity(invoke: Invoke) {
+    fun setParity(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val parity = when (args.parity) {
@@ -490,7 +501,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setStopBits(invoke: Invoke) {
+    fun setStopBits(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val stopBits = when (args.stopBits) {
@@ -511,7 +522,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setTimeout(invoke: Invoke) {
+    fun setTimeout(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val success = serialPortManager.setTimeout(args.path, args.timeout)
@@ -526,7 +537,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun writeRequestToSend(invoke: Invoke) {
+    fun writeRequestToSend(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val success = serialPortManager.writeRequestToSend(args.path, args.flowControl == "HARDWARE")
@@ -541,7 +552,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun writeDataTerminalReady(invoke: Invoke) {
+    fun writeDataTerminalReady(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val success = serialPortManager.writeDataTerminalReady(args.path, args.flowControl == "HARDWARE")
@@ -556,7 +567,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun readClearToSend(invoke: Invoke) {
+    fun readClearToSend(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val state = serialPortManager.readClearToSend(args.path)
@@ -569,7 +580,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun readDataSetReady(invoke: Invoke) {
+    fun readDataSetReady(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val state = serialPortManager.readDataSetReady(args.path)
@@ -582,7 +593,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun readRingIndicator(invoke: Invoke) {
+    fun readRingIndicator(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val state = serialPortManager.readRingIndicator(args.path)
@@ -595,7 +606,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun readCarrierDetect(invoke: Invoke) {
+    fun readCarrierDetect(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val state = serialPortManager.readCarrierDetect(args.path)
@@ -608,7 +619,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun bytesToRead(invoke: Invoke) {
+    fun bytesToRead(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val bytes = serialPortManager.bytesToRead(args.path)
@@ -621,7 +632,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun bytesToWrite(invoke: Invoke) {
+    fun bytesToWrite(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val bytes = serialPortManager.bytesToWrite(args.path)
@@ -634,7 +645,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun clearBuffer(invoke: Invoke) {
+    fun clearBuffer(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(PortConfigArgs::class.java)
             val bufferType = when (args.dataBits) {
@@ -655,7 +666,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun setBreak(invoke: Invoke) {
+    fun setBreak(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val success = serialPortManager.setBreak(args.path)
@@ -670,7 +681,7 @@ class SerialPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     @Command
-    fun clearBreak(invoke: Invoke) {
+    fun clearBreak(invoke: Invoke) = runOnIoThread(invoke) {
         try {
             val args = invoke.parseArgs(CloseArgs::class.java)
             val success = serialPortManager.clearBreak(args.path)


### PR DESCRIPTION
## Problem

On Android, every plugin command invoked from Rust via `run_mobile_plugin` executes **synchronously on the Android main (UI) thread**: tauri's `run_on_android_context` posts the JNI call through wry's `MainPipe` to the main looper, where `PluginManager.runCommand` invokes the `@Command` method inline — there is no executor anywhere in that chain.

This means `readFromPort`'s blocking `UsbSerialPort.read(buffer, timeout)` (coerced to >= 200 ms) runs on the UI thread. An app that polls `read_binary` to drain a continuous stream blocks the main thread for the full read duration on every call — and since Android returns at most one USB bulk packet (~64 bytes) per read, draining even a modest ~10 KB/s stream means 160+ blocking main-thread reads per second. The app UI freezes completely while streaming; when the port is idle, each poll stalls the UI for the full 200 ms timeout.

`open()` has the same issue in a worse form: it can block the main thread while waiting for the USB permission broadcast — which is delivered on that same main thread.

Marking the Rust command `#[tauri::command(async)]` does not help; that only moves the *Rust* side off-thread, the Kotlin body still runs on the main looper.

## Fix

Run the port IO command bodies (`open`, `close`, `closeAll`, `forceClose`, `write`, `writeBinary`, `read`, `readBinary`) on a dedicated single-thread executor:

- a **single** thread preserves command ordering (open before read, close after pending read, etc.);
- resolving an `Invoke` from a worker thread already has precedent in this plugin — `Channel.send` is called from the `SerialInputOutputManager` IO thread;
- the executor is shut down when the host activity is destroyed (same lifecycle hook that releases the ports).

## Testing

- `gradlew compileDebugKotlin` clean.
- Verified on a real device (equine gait-analysis app, 4 IMU sensors at 200 Hz over 1 Mbaud USB serial, polled `read_binary` from a Rust reader thread): before the patch the UI froze as soon as streaming started; with it the app stays fully responsive with no data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run all Android serial port work off the main thread by executing every `SerialPortManager` command on a dedicated single-thread executor. This keeps the UI responsive and preserves strict ordering across IO, config, and status operations.

- **Bug Fixes**
  - Funneled all commands (`open/close`, `read*/write*`, `startListening/stopListening`, config/status getters/setters) through `runOnIoThread` to prevent main-thread blocking and `portMap` races.
  - On activity destroy, enqueue `serialPortManager.cleanup()` as the final executor task, then call `shutdown()`; fall back to direct cleanup if the executor is already stopped.
  - Introduced `runOnIoThread` and reject `Invoke` if the executor is shut down.

<sup>Written for commit 981fddb143c77535c45d2a71f46f2cf613c9038f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/s00d/tauri-plugin-serialplugin/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

